### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
-  - hhvm
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/process": "~2.3|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "~6.0"
     },
     "bin": [
         "laravel"

--- a/tests/NewCommandTest.php
+++ b/tests/NewCommandTest.php
@@ -13,7 +13,7 @@ use Guzzle\Common\Exception\RuntimeException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-use PHPUnit_Framework_TestCase as PhpUnit;
+use PHPUnit\Framework\TestCase as PhpUnit;
 
 class NewCommandTest extends PhpUnit
 {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).